### PR TITLE
Add the posibility to add driver namespace

### DIFF
--- a/Mapping/MappingDriverChain.php
+++ b/Mapping/MappingDriverChain.php
@@ -61,12 +61,17 @@ class MappingDriverChain implements MappingDriver
      * Adds a nested driver.
      *
      * @param MappingDriver $nestedDriver
+     * @param string|null   $namespace
      *
      * @return void
      */
-    public function addDriver(MappingDriver $nestedDriver)
+    public function addDriver(MappingDriver $nestedDriver, $namespace = null)
     {
-        $this->drivers[] = $nestedDriver;
+        if (null === $namespace) {
+            $this->drivers[] = $nestedDriver;
+        } else {
+            $this->drivers[$namespace] = $nestedDriver;
+        }
     }
 
     /**


### PR DESCRIPTION
Hi, in some other bundles, for example `StofDoctrineExtensionsBundle` is required to fill the drivers array key with the namespace of the class to make it work.
I don't know if this will affect the behavior of the bundle, I hope not.
Thanks!
